### PR TITLE
moved the creation of the 'signif' column into the 'roots' loop to account for different ontology FWER thresholds

### DIFF
--- a/R/refine.R
+++ b/R/refine.R
@@ -106,7 +106,7 @@ refine = function(res, fwer=0.05, fwer_col=7, annotations=NULL){
 
     # merge with original data, all=T just to be sure, should always have the same
     out = merge(signi_stats, refined, by="node_id", all=TRUE, sort=FALSE)
-    out$signif = out$refined_p < pval
+
     # remove raw_p column after testing
     out = out[, colnames(out) != "raw_p"] 
     colnames(out)[colnames(out) == "refined_p"] = paste0("refined_", substring(pcol_string, 5))
@@ -173,6 +173,7 @@ refine_algo = function(anno_signi, scores_root, sub_graph_path, pval, refined, t
     
     # add to output
     refined[match(new_p_leaves$go_id, refined$node_id), "refined_p"] = new_p_leaves$new_p
+    refined[match(new_p_leaves$go_id, refined$node_id), "signif"] = new_p_leaves$new_p < pval
 
     # check that p-value for leaves is the same before and after refinement
     if (first){


### PR DESCRIPTION
Resolved a minor issue that resulted in incorrect significance labels for refined results. In brief, calculation of the ontology-specific FWER pvalues is done while looping across the three GO aspects. However, comparisons of the refined category pvalues against the FWER pval for column 'signif' was originally done after completion of the loop, so that all comparisons were based on the FWER pval of the last iteration, i.e., the last GO aspect. This resulted in refined p-values that did not pass FWER even if p-values remained unchanged.